### PR TITLE
Add options.ignoreMissingSelector

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,8 @@ Defaults options
 
 * `title = "Content"` — Title TOC block
 * `after = "h1"` — tag after which the TOC will be inserted
-
+* `ignoreMissingSelector = false` — throw an error if the selector is not found
+* `toggle` is undefined
 
 ### `after` options
 
@@ -144,6 +145,47 @@ After:
   </body>
 </html>
 ```
+
+### `ignoreMissingSelector` option
+
+* `{ ignoreMissingSelector: false }` (_default_) — throw an error if the
+  selector (the default `h1` tag or the value passed to `options.after`) is not
+  found.
+
+  For example, with this option, you get an error on the second file because
+  there is no `h1` tag:
+
+  ```html
+  <!-- file-with-toc.html -->
+  <h1>Title 1</h1>
+  <h2 id="title2">Title 2</h2>
+  ```
+
+  ```html
+  <!-- file-without-toc.html -->
+  <div></div>
+  ```
+
+* `{ ignoreMissingSelector: true }` — ignore HTML input that does not have
+  the selector.
+
+  This is useful if you want to uniformly process a number of files but don't
+  want to insert a TOC in all of them.
+
+  For example, with the files mentioned above, instead of an error, the first
+  file is modified and the second file is unchanged:
+
+  ```html
+  <!-- file-with-toc.html -->
+  <h1>Title 1</h1>
+  <div id="toc"><h2>Content</h2><ul><li><a href="#title2">Title 2</a></li></ul></div>
+  <h2 id="title2">Title 2</h2>
+  ```
+
+  ```html
+  <!-- file-without-toc.html -->
+  <div></div>
+  ```
 
 ### Contributing
 

--- a/test/fixtures/unchanged.expected.html
+++ b/test/fixtures/unchanged.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<p>Text</p>
+<h2>Title 2</h2>
+<p>Text</p>
+</body>
+</html>

--- a/test/fixtures/unchanged.html
+++ b/test/fixtures/unchanged.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<p>Text</p>
+<h2>Title 2</h2>
+<p>Text</p>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,10 @@ test(`invalid 'options.toggle' throws error`, (t) => {
   invalidOptions(t, { toggle: ['hide', true] }, `unexpected 'options.toggle': hide,true`)
 })
 
+test(`invalid 'options.ignoreMissingSelector' throws error`, (t) => {
+  invalidOptions(t, { ignoreMissingSelector: 42 }, `unexpected 'options.ignoreMissingSelector': 42`)
+})
+
 test('basic', (t) => {
   return compare(t, 'basic')
 })
@@ -43,6 +47,10 @@ test('selector not found throws error', async (t) => {
   const e = await t.throwsAsync(posthtml([plugin()]).process())
   t.is(e.name, 'PostHtmlTocError')
   t.is(e.message, `selector not found: h1`)
+})
+
+test('ignoreMissingSelector does not throw error', (t) => {
+  return compare(t, 'unchanged', { after: '#id-not-found', ignoreMissingSelector: true })
 })
 
 // const debug = function (html) {


### PR DESCRIPTION
Add the option `errorIfSelectorNotFound`, which, if `false`, prevents an error from being thrown if the selector is not found.

Fixes #6