### PR TITLE
Allow inserting in more places

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,21 +71,83 @@ posthtml()
 
 Defaults options
 
+* `insert = { after: 'h1' }` — insert the TOC immediately after the first `<h1>`
 * `title = "Content"` — Title TOC block
-* `after = "h1"` — tag after which the TOC will be inserted
 * `ignoreMissingSelector = false` — throw an error if the selector is not found
 * `ignoreMissingHeadings = false` — throw an error if the no headings are found
 * `toggle` is undefined
 
-### `after` options
+### `insert` option
 
-Set tag, class, or id after which the TOC will be inserted
+This option allows you to specify where the TOC will be inserted in the HTML
+output. The option expects an object with **exactly one key** with a string
+value, as in this schema:
 
-```js
-  after: 'tag'
-  after: '.class'
-  after: '#id'
 ```
+{ insert: { <position>: <selector> } }
+```
+
+`<selector>` is a string used to select an HTML element by matching one of three
+patterns:
+
+* `'<tag>'` — matches the first element with the name `<tag>`.
+
+  _Example_: `'nav'` matches `<nav>`.
+
+* `'#<id>'` — matches the first element with `<id>` as the `id` attribute value.
+
+  _Example_: `'#here'` matches `<div id="here">`.
+
+* `'.<class>'` — matches the first element with `<class>` as one of the
+  space-separated strings in the `class` attribute value.
+
+  _Example_: `'.here'` matches `<div class="are you here or there">`.
+
+`<position>` can be one of the following:
+
+* `after` — The TOC will be inserted immediately after the matching node.
+
+  _Example_: `{ insert: { after: 'h1' } }` (_default_) produces:
+
+  ```diff
+   <h1>...</h1>
+  +<div id="toc">...</div>
+   <p>...</p>
+  ```
+
+* `before` — The TOC will be inserted immediately before the matching node.
+
+  _Example_: `{ insert: { before: '#here' } }` produces:
+
+  ```diff
+   <p>...</p>
+  +<div id="toc">...</div>
+   <div id="here">...</div>
+  ```
+
+* `afterChildren` — The TOC will be inserted into the contents of the matching
+  node after the last child.
+
+  _Example_: `{ insert: { afterChildren: '.here' } }` produces:
+
+  ```diff
+   <nav class="here">
+     <p>...</p>
+  +  <div id="toc">...</div>
+   </nav>
+  ```
+
+* `beforeChildren` — The TOC will be inserted into the contents of the matching
+  node before the first child.
+
+  _Example_: `{ insert: { beforeChildren: '.here' } }` produces:
+
+  ```diff
+   <nav class="here">
+  +  <div id="toc">...</div>
+     <p>...</p>
+   </nav>
+  ```
 
 ### `toggle` options
 Before:

--- a/test/fixtures/afterChildren-no-children1.expected.html
+++ b/test/fixtures/afterChildren-no-children1.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav><div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div></nav>
+</body>
+</html>

--- a/test/fixtures/afterChildren-no-children1.html
+++ b/test/fixtures/afterChildren-no-children1.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav></nav>
+</body>
+</html>

--- a/test/fixtures/afterChildren-no-children2.expected.html
+++ b/test/fixtures/afterChildren-no-children2.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav><div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div></nav>
+</body>
+</html>

--- a/test/fixtures/afterChildren-no-children2.html
+++ b/test/fixtures/afterChildren-no-children2.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav></nav>
+</body>
+</html>

--- a/test/fixtures/afterChildren.expected.html
+++ b/test/fixtures/afterChildren.expected.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav>
+  <p>More..</p>
+<div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div></nav>
+</body>
+</html>

--- a/test/fixtures/afterChildren.html
+++ b/test/fixtures/afterChildren.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav>
+  <p>More..</p>
+</nav>
+</body>
+</html>

--- a/test/fixtures/before.expected.html
+++ b/test/fixtures/before.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<p>Text</p><div id="toc"><h2>Content</h2><ul><li><a href="#title2">Title 2</a></li></ul></div>
+<h2 id="title2">Title 2</h2>
+<p>Text</p>
+</body>
+</html>

--- a/test/fixtures/before.html
+++ b/test/fixtures/before.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<p>Text</p>
+<h2 id="title2">Title 2</h2>
+<p>Text</p>
+</body>
+</html>

--- a/test/fixtures/beforeChildren-no-children1.expected.html
+++ b/test/fixtures/beforeChildren-no-children1.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav class="no-children"><div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div></nav>
+</body>
+</html>

--- a/test/fixtures/beforeChildren-no-children1.html
+++ b/test/fixtures/beforeChildren-no-children1.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav class="no-children"></nav>
+</body>
+</html>

--- a/test/fixtures/beforeChildren-no-children2.expected.html
+++ b/test/fixtures/beforeChildren-no-children2.expected.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav class="no-children"><div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div>
+</nav></body>
+</html>

--- a/test/fixtures/beforeChildren-no-children2.html
+++ b/test/fixtures/beforeChildren-no-children2.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav class="no-children"/>
+</body>
+</html>

--- a/test/fixtures/beforeChildren.expected.html
+++ b/test/fixtures/beforeChildren.expected.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav><div id="toc"><h2>Content</h2><ul><li><a href="#ha">HA</a></li><li><a href="#hb">HB</a></li></ul></div>
+  <p>More..</p>
+</nav>
+</body>
+</html>

--- a/test/fixtures/beforeChildren.html
+++ b/test/fixtures/beforeChildren.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>Title 1</h1>
+<h2 id="ha">HA</h2>
+<h2 id="hb">HB</h2>
+<nav>
+  <p>More..</p>
+</nav>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -7,8 +7,25 @@ const path = require('path')
 const posthtml = require('posthtml')
 const fixtures = path.join(__dirname, 'fixtures')
 
-test(`invalid 'options.after' throws error`, (t) => {
-  invalidOptions(t, { after: 5 }, `unexpected 'options.after': 5`)
+test(`invalid 'options.insert' throws error`, (t) => {
+  invalidOptions(t, { insert: 5 }, `unexpected 'options.insert': 5`)
+})
+
+test(`invalid 'options.insert' with no keys throws error`, (t) => {
+  invalidOptions(t, { insert: {} }, `empty 'options.insert'`)
+})
+
+test(`invalid 'options.insert' with >1 key throws error`, (t) => {
+  invalidOptions(t, { insert: { after: 'h1', before: 'h2' } },
+    'too many keys in \'options.insert\': after,before')
+})
+
+test(`invalid 'options.insert' with invalid key throws error`, (t) => {
+  invalidOptions(t, { insert: { life: 42 } }, `unexpected 'options.insert' key: life`)
+})
+
+test(`invalid 'options.insert' with invalid valid throws error`, (t) => {
+  invalidOptions(t, { insert: { beforeChildren: undefined } }, `unexpected 'options.insert' value: undefined`)
 })
 
 test(`invalid 'options.title' throws error`, (t) => {
@@ -31,16 +48,44 @@ test('basic', (t) => {
   return compare(t, 'basic')
 })
 
+test('before', (t) => {
+  return compare(t, 'before', { insert: { before: '#title2' } })
+})
+
+test('afterChildren', (t) => {
+  return compare(t, 'afterChildren', { insert: { afterChildren: 'nav' } })
+})
+
+test('afterChildren with no children (1)', (t) => {
+  return compare(t, 'afterChildren-no-children1', { insert: { afterChildren: 'nav' } })
+})
+
+test('afterChildren with no children (2)', (t) => {
+  return compare(t, 'afterChildren-no-children2', { insert: { afterChildren: 'nav' } })
+})
+
+test('beforeChildren', (t) => {
+  return compare(t, 'beforeChildren', { insert: { beforeChildren: 'nav' } })
+})
+
+test('beforeChildren with no children (1)', (t) => {
+  return compare(t, 'beforeChildren-no-children1', { insert: { beforeChildren: '.no-children' } })
+})
+
+test('beforeChildren with no children (2)', (t) => {
+  return compare(t, 'beforeChildren-no-children2', { insert: { beforeChildren: '.no-children' } })
+})
+
 test('toggle', (t) => {
-  return compare(t, 'toggle', { after: 'p', title: 'Test', toggle: ['show', 'hide'] })
+  return compare(t, 'toggle', { insert: { after: 'p' }, title: 'Test', toggle: ['show', 'hide'] })
 })
 
 test('class', (t) => {
-  return compare(t, 'class', { after: '.p' })
+  return compare(t, 'class', { insert: { after: '.p' } })
 })
 
 test('id', (t) => {
-  return compare(t, 'id', { after: '#p' })
+  return compare(t, 'id', { insert: { after: '#p' } })
 })
 
 test('oncetitle', (t) => {
@@ -52,7 +97,7 @@ test('selector not found throws error', async (t) =>
 )
 
 test('ignoreMissingSelector does not throw error', (t) => {
-  return compare(t, 'unchanged', { after: '#id-not-found', ignoreMissingSelector: true })
+  return compare(t, 'unchanged', { insert: { after: '#id-not-found' }, ignoreMissingSelector: true })
 })
 
 test('missing headings throws error', async (t) =>


### PR DESCRIPTION
* Make the approach to inserting the TOC more flexible by allowing `options.insert` to be specified with the positions `after`, `before`, `afterChildren`, and `beforeChildren`.
* Remove `options.after`.
* Fixes #4