### PR TITLE
Handle missing headings better

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Defaults options
 * `title = "Content"` — Title TOC block
 * `after = "h1"` — tag after which the TOC will be inserted
 * `ignoreMissingSelector = false` — throw an error if the selector is not found
+* `ignoreMissingHeadings = false` — throw an error if the no headings are found
 * `toggle` is undefined
 
 ### `after` options
@@ -186,6 +187,17 @@ After:
   <!-- file-without-toc.html -->
   <div></div>
   ```
+
+### `ignoreMissingHeadings` option
+
+This option controls what happens when no headings (`h2`, `h3`, `h4`, `h5`,
+`h6`) are found in the HTML input.
+
+* `{ ignoreMissingHeadings: false }` (_default_) — throw an error if no headings
+  are found.
+
+* `{ ignoreMissingHeadings: true }` — do not throw an error if no headings are
+  found. Instead, a TOC with an empty list (i.e. `<ul></ul>`) will be inserted.
 
 ### Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,15 @@
  * @prop {?Array[String, String, Boolean]} options.toggle - toggle button text options
  * @prop {?boolean} options.ignoreMissingSelector - don't throw an error if the
  *   selector is not found
+ * @prop {?boolean} options.ignoreMissingHeadings - don't throw an error if no
+ *   headings (h2,h3,h4,h5,h6) are not found
  */
 module.exports = function (options = {}) {
   const {
     after = 'h1',
     title = 'Content',
     ignoreMissingSelector = false,
+    ignoreMissingHeadings = false,
     toggle // ['show', 'hide', true],
   } = options
 
@@ -37,6 +40,10 @@ module.exports = function (options = {}) {
 
   if (typeof ignoreMissingSelector !== 'boolean') {
     throw new PostHtmlTocError(`unexpected 'options.ignoreMissingSelector': ${ignoreMissingSelector}`)
+  }
+
+  if (typeof ignoreMissingHeadings !== 'boolean') {
+    throw new PostHtmlTocError(`unexpected 'options.ignoreMissingHeadings': ${ignoreMissingHeadings}`)
   }
 
   return function toc (tree) {
@@ -135,6 +142,14 @@ module.exports = function (options = {}) {
       rollUp(list)
     }
 
+    const tocItems = list[0]
+
+    // If there are no headings in the HTML, we throw an error. Otherwise, if
+    // `ignoreMissingHeadings === true`, we output an empty `<ul>`.
+    if (tocItems.length < 1 && ignoreMissingHeadings === false) {
+      throw new PostHtmlTocError('no headings (h2,h3,h4,h5,h6) found')
+    }
+
     function render (list) {
       const content = []
       list.forEach(function (item) {
@@ -178,7 +193,7 @@ module.exports = function (options = {}) {
           toggle && { tag: 'input', attrs: { type: 'checkbox', role: 'button', id: 'toctoggle', checked: toggle[2] } },
           title && { tag: 'h2', content: [title] },
           toggle && { tag: 'label', attrs: { for: 'toctoggle' } },
-          render(list[0])
+          render(tocItems)
         ].filter(Boolean)
       }
     )

--- a/test/fixtures/ignore-missing-headings.expected.html
+++ b/test/fixtures/ignore-missing-headings.expected.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Title 1</h1><div id="toc"><h2>Content</h2><ul></ul></div>
+</body>
+</html>

--- a/test/fixtures/ignore-missing-headings.html
+++ b/test/fixtures/ignore-missing-headings.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Title 1</h1>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,10 @@ test(`invalid 'options.ignoreMissingSelector' throws error`, (t) => {
   invalidOptions(t, { ignoreMissingSelector: 42 }, `unexpected 'options.ignoreMissingSelector': 42`)
 })
 
+test(`invalid 'options.ignoreMissingHeadings' throws error`, (t) => {
+  invalidOptions(t, { ignoreMissingHeadings: [] }, `unexpected 'options.ignoreMissingHeadings': `)
+})
+
 test('basic', (t) => {
   return compare(t, 'basic')
 })
@@ -51,6 +55,18 @@ test('selector not found throws error', async (t) => {
 
 test('ignoreMissingSelector does not throw error', (t) => {
   return compare(t, 'unchanged', { after: '#id-not-found', ignoreMissingSelector: true })
+})
+
+test('missing headings throws error', async (t) => {
+  const e = await t.throwsAsync(
+    posthtml([plugin()]).process('<html><body><h1/></body></html>')
+  )
+  t.is(e.name, 'PostHtmlTocError')
+  t.is(e.message, 'no headings (h2,h3,h4,h5,h6) found')
+})
+
+test('ignoreMissingHeadings does not throw error', (t) => {
+  return compare(t, 'ignore-missing-headings', { ignoreMissingHeadings: true })
 })
 
 // const debug = function (html) {


### PR DESCRIPTION
* Add an error that is thrown when no headings are found in the HTML.
* Add `options.ignoreMissingHeadings` to disable the error.